### PR TITLE
Mock Github API requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,15 +1,16 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 ruby '2.2.0'
-gem 'sinatra'
+
 gem 'octokit', '~> 4.0'
+gem 'sinatra'
 
 group :development, :test do
   gem 'dotenv'
 end
 
 group :test do
-  gem 'rspec-sinatra'
+  gem 'byebug'
   gem 'capybara'
   gem 'rspec'
-  gem 'byebug'
+  gem 'rspec-sinatra'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,5 +72,8 @@ DEPENDENCIES
   rspec-sinatra
   sinatra
 
+RUBY VERSION
+   ruby 2.2.0p0
+
 BUNDLED WITH
-   1.11.2
+   1.12.3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # GDS-Github-Trello
+[![Build Status](https://travis-ci.org/emmabeynon/gds-github-trello.svg?branch=master)](https://travis-ci.org/emmabeynon/gds-github-trello)
 
 ## The Problem
 App that queries Github’s API to look at alphagov’s PRs, and when a link to a Trello card is mentioned in the PR, post a message to the team’s Trello board, with the reference of the PR.
@@ -25,5 +26,8 @@ I would like a link to relevant PRs to be automatically added to the Trello card
 - Fixed Octokit pagination so that all repos are retrieved
 - Set up Travis CI
 
+**09/05/16**
+- Github API is mocked using let statements
+
 #### Next:
-- Mock Github API
+- Grab commits and/or pull request comments for each pull request

--- a/lib/github_pr_scraper.rb
+++ b/lib/github_pr_scraper.rb
@@ -19,9 +19,8 @@ class GitHubPrScraper
 
   def fetch_pull_requests
     repos.each do |repo|
-      if !login_user.pull_requests(repo.id).empty?
-        @pull_requests << login_user.pull_requests(repo.id)
-      end
+      repo_pull_requests = login_user.pull_requests(repo[:id])
+      @pull_requests << repo_pull_requests if !repo_pull_requests.empty?
     end
     @pull_requests.flatten!
   end

--- a/spec/github_pr_scraper_spec.rb
+++ b/spec/github_pr_scraper_spec.rb
@@ -2,6 +2,16 @@ require 'github_pr_scraper'
 
 describe GitHubPrScraper do
   subject(:scraper) { GitHubPrScraper.new }
+  let(:octokit) { double Octokit::Client }
+  let(:repos) { [{ id: 7052482 }, { id: 56678576 }] }
+  let(:repo_pull_requests) { [{url: 'https://api.github.com/repos/alphagov/govspeak/pulls/69'}] }
+
+  before(:each) do
+    allow(octokit).to receive(:new).and_return(octokit)
+    allow(octokit).to receive(:auto_paginate=).and_return true
+    allow(scraper.login_user).to receive(:organization_repositories).and_return(repos)
+    allow(scraper.login_user).to receive(:pull_requests).and_return(repo_pull_requests)
+  end
 
   describe 'Default' do
     it 'initializes with login_user set to an authenticated Github user' do
@@ -13,7 +23,7 @@ describe GitHubPrScraper do
     end
 
     it 'initializes with an organisation set to \'alphagov\'' do
-      expect(scraper.organisation).to eq 'alphagov'
+      expect(scraper.organisation).to eq GitHubPrScraper::ORGANISATION
     end
 
     it 'initializes with pull_requests set to an empty array' do


### PR DESCRIPTION
- GitHubPrScraper tests are now mocked using let statements
- This is to prevent exceeding API rate limits and speed up tests
- [Trello card] (https://trello.com/c/Hl3Vp62o/15-mock-github-api)