### PR TITLE
Add filter for Trello cards in commit messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,5 +30,15 @@ I would like a link to relevant PRs to be automatically added to the Trello card
 - Github API is mocked using let statements
 - Now able to fetch a list of commits from each open pull request
 
+**16/05/16**
+- Fetch pull requests method changed to use Github search to grab all open pull requests on Alphagov, which has sped up the interaction with the API
+- Fetch commits method has been altered to work with the new fetch pull requests method
+- Fetch repos has been removed as it's now redundant
+
+**01/06/16**
+- Method created to filter commits for links to Trello cards
+- Currently using two data structures - one to store all PR URLs and commit body, and one to store PR URLs filtered by those containing a Trello card URL in the commit body.  Unsure at this point whether the combine the two, but will see how the code develops.
+
 #### Next:
-- Filter commits for links to Trello cards
+- Access Trello card
+- Set up dummy Github organisation for feature tests

--- a/lib/github_pr_scraper.rb
+++ b/lib/github_pr_scraper.rb
@@ -1,5 +1,5 @@
 class GitHubPrScraper
-  attr_reader :commits, :login_user, :pull_requests
+  attr_reader :commits, :login_user, :prs_and_trello_card_ids, :pull_requests
 
   ORGANISATION = ENV['GITHUB_ORGANISATION']
 
@@ -8,6 +8,7 @@ class GitHubPrScraper
     @login_user = authenticate
     @login_user.auto_paginate = true
     @pull_requests = nil
+    @prs_and_trello_card_ids = {}
   end
 
   def fetch_pull_requests
@@ -17,6 +18,15 @@ class GitHubPrScraper
   def fetch_commits
     @commits = pull_requests.each_with_object({}) do | pr, hash |
       hash[pr[:pull_request][:html_url]] = pr[:body]
+    end
+  end
+
+  def filter_trello_card_ids
+    commits.each do |k,v|
+      trello_card_present = v.match(/https:\/\/trello.com\/c\/\w{8}/) if v
+      if trello_card_present
+        @prs_and_trello_card_ids[k] = trello_card_present[0].gsub(/https:\/\/trello.com\/c\//, '')
+      end
     end
   end
 

--- a/spec/github_api_spec.rb
+++ b/spec/github_api_spec.rb
@@ -14,4 +14,11 @@ describe 'Github API' do
     expect(scraper.commits).not_to be nil
   end
 
+  it 'returns a list of pull request URLs and corresponding Trello card IDs' do
+    scraper.fetch_pull_requests
+    scraper.fetch_commits
+    scraper.filter_trello_card_ids
+    expect(scraper.prs_and_trello_card_ids).not_to be nil
+  end
+
 end

--- a/spec/github_pr_scraper_spec.rb
+++ b/spec/github_pr_scraper_spec.rb
@@ -5,7 +5,8 @@ describe GitHubPrScraper do
 
   let(:octokit) { double Octokit::Client }
   let(:commits) do
-    { 'https://github.com/alphagov/transition/pull/511' => 'A commit with a Trello URL https://trello.com/c/Xf9vMxZ9/5-grab-all-commit-messages-from-open-pull-requests' }
+    { 'https://github.com/alphagov/transition/pull/511' =>
+      'A commit with a Trello URL https://trello.com/c/Xf9vMxZ9/5-grab-all-commit-messages-from-open-pull-requests' }
   end
   let(:repo_pull_requests) do
     { items: [
@@ -14,6 +15,9 @@ describe GitHubPrScraper do
         body: 'A commit with a Trello URL https://trello.com/c/Xf9vMxZ9/5-grab-all-commit-messages-from-open-pull-requests'
       }
     ] }
+  end
+  let(:prs_and_trello_card_ids) do
+    { 'https://github.com/alphagov/transition/pull/511' => 'Xf9vMxZ9'}
   end
 
   before(:each) do
@@ -34,6 +38,10 @@ describe GitHubPrScraper do
     it 'initializes with pull_requests set to nil' do
       expect(scraper.commits).to be_nil
     end
+
+    it 'initializes with prs_and_trello_card_ids set to an empty hash' do
+      expect(scraper.prs_and_trello_card_ids).to be {}
+    end
   end
 
   describe '#fetch_pull_requests' do
@@ -48,6 +56,15 @@ describe GitHubPrScraper do
       scraper.fetch_pull_requests
       scraper.fetch_commits
       expect(scraper.commits).to eq commits
+    end
+  end
+
+  describe '#filter_trello_card_ids' do
+    it 'returns a list of pull request URLs and corresponding Trello card numbers from the commits' do
+      scraper.fetch_pull_requests
+      scraper.fetch_commits
+      scraper.filter_trello_card_ids
+      expect(scraper.prs_and_trello_card_ids).to eq prs_and_trello_card_ids
     end
   end
 


### PR DESCRIPTION
- Added filter_trello_card_ids method
- Checks body of commits for a Trello card URL
- Creates a new hash containing the PR URL as the key and the Trello card ID (found in the Trello card URL) as the value
- [Trello card 1 - filter commit messages for Trello URLs](https://trello.com/c/6sF9kBGz/6-filter-commit-messages-for-trello-urls)
- [Trello card 2 - capture trello link from PR](https://trello.com/c/nSi9V8IV/7-capture-trello-link-from-pr)
- [Trello card 3 - capture Github PR URL](https://trello.com/c/PqLlXSDv/8-capture-the-github-pr-url)