### PR TITLE
Update feature tests to work with dummy organisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ I would like a link to relevant PRs to be automatically added to the Trello card
 **03/06/16**
 - Added ruby-trello gem to interact with the Trello API
 - Trello is authenticated using basic authentication - struggling to make it work using OAuth currently.
+- Set up a dummy Github organisation for testing
+- Changed feature tests to work with dummy Github organisation
 
 #### Next:
 - Access Trello card
-- Set up dummy Github organisation for feature tests

--- a/spec/features/github_api_spec.rb
+++ b/spec/features/github_api_spec.rb
@@ -5,20 +5,20 @@ describe 'Github API' do
 
   it 'returns a list of pull requests on Alphagov' do
     scraper.fetch_pull_requests
-    expect(scraper.pull_requests).not_to be_empty
+    expect(scraper.pull_requests.any? { |pr| pr[:url] == "https://api.github.com/repos/gov-test-org/project-b/issues/1" }).to be true
   end
 
   it 'returns a list of commits from pull requests on Alphagov' do
     scraper.fetch_pull_requests
     scraper.fetch_commits
-    expect(scraper.commits).not_to be nil
+    expect(scraper.commits).to include("https://github.com/gov-test-org/project-a/pull/2" => "Trello card is https://trello.com/c/AEjA9me7/20-add-testfile-2-txt-to-project-a")
   end
 
   it 'returns a list of pull request URLs and corresponding Trello card IDs' do
     scraper.fetch_pull_requests
     scraper.fetch_commits
     scraper.filter_trello_card_ids
-    expect(scraper.prs_and_trello_card_ids).not_to be nil
+    expect(scraper.prs_and_trello_card_ids).to include("https://github.com/gov-test-org/project-b/pull/1"=>"6wQLN2C7")
   end
 
 end


### PR DESCRIPTION
- A dummy organisation has been created for testing
- This should provide a more robust testing approach as pull requests can remain open, unlike alphagov where PR status is fluid