### PR TITLE
Fix PR URL duplicate posting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 App that queries Github’s API to look at alphagov’s PRs, and when a link to a Trello card is mentioned in the PR, post a message to the team’s Trello board, with the reference of the PR.
 
 ## User Stories
-As a GOV.UK developer
+`As a GOV.UK developer
 
 So that I can make sure that the Trello card I am working on has the correct PR information
 
-I would like a link to relevant PRs to be automatically added to the Trello card.
+I would like a link to relevant PRs to be automatically added to the Trello card.`
 
 ## Log
 **22/04/16**
@@ -59,6 +59,10 @@ I would like a link to relevant PRs to be automatically added to the Trello card
 **17/06/16**
 - TrelloPoster is now injected as a dependency in the GitHubPrScraper class
 - GitHubPrScraper iterates through prs_and_trello_card_ids and creates an instance of the TrelloPoster class to post the PR URL to the Trello card
+
+**04/07/16**
+- TrelloPoster and GitHubPrScraper classes refactored to reduce dependency on each other
+- Added functionality to check if a given PR URL is already in the Pull Requests checklist.  If it is, then it will not be posted again.
 
 #### Next:
 - Wire up classes to Sinatra

--- a/lib/github_pr_scraper.rb
+++ b/lib/github_pr_scraper.rb
@@ -1,4 +1,5 @@
-require 'trello_poster'
+require_relative 'trello_poster'
+require 'octokit'
 
 class GitHubPrScraper
   attr_reader :commits, :login_user, :pull_requests, :trello_poster

--- a/lib/trello_poster.rb
+++ b/lib/trello_poster.rb
@@ -26,7 +26,9 @@ class TrelloPoster
 
   def post_github_pr_url
     checklist = Trello::Checklist.find(pr_checklist)
-    checklist.add_item(pr_url, checked=false, position='bottom')
+    unless checklist.check_items.detect { |item| item["name"] == pr_url }
+      checklist.add_item(pr_url, checked=false, position='bottom')
+    end
   end
 
 private

--- a/spec/features/pr_poster_spec.rb
+++ b/spec/features/pr_poster_spec.rb
@@ -19,4 +19,22 @@ describe 'Pull Request Poster' do
     checklist.delete_checklist_item(checklist.check_items.first['id'])
     checklist.delete
   end
+
+  it 'does not post a pull request URL to a Trello card if it already exists in the card\'s PR checklist' do
+    2.times do
+      scraper.fetch_pull_requests
+      scraper.fetch_commits
+      scraper.filter_commits
+    end
+
+    pr_url = scraper.commits.keys.first
+    trello_card_id = scraper.commits[pr_url].match(/https:\/\/trello.com\/c\/\w{8}/)[0].gsub(/https:\/\/trello.com\/c\//, '')
+
+    trello_card = Trello::Card.find(trello_card_id)
+
+    checklist = trello_card.checklists.first
+    expect(checklist.check_items.count).to eq(1)
+
+    checklist.delete_checklist_item(checklist.check_items.first['id'])
+  end
 end

--- a/spec/features/trello_api_spec.rb
+++ b/spec/features/trello_api_spec.rb
@@ -9,24 +9,30 @@ describe 'Trello API' do
   end
 
   it 'checks if a checklist called "Pull Requests" is present' do
-    trello_poster_1.access_trello_card
     expect(trello_poster_1.pr_checklist).to eq('5763eec88f68ea12654b44a7')
   end
 
   it 'creates a checklist called "Pull Requests" if there is not one present' do
-    trello_poster_2.access_trello_card
     expect(trello_poster_2.pr_checklist).not_to be nil
 
     Trello::Checklist.find(trello_poster_2.pr_checklist).delete
   end
 
   it 'posts a GitHub PR URL to a Trello card checklist called "Pull Requests"' do
-    trello_poster_1.access_trello_card
-    trello_poster_1.post_github_pr_url
-
     checklist = Trello::Checklist.find(trello_poster_1.pr_checklist)
 
     expect(checklist.check_items.first['name']).to eq('https://github.com/gov-test-org/project-a/pull/1')
+
+    checklist.delete_checklist_item(checklist.check_items.first['id'])
+  end
+
+  it 'does not post a Github PR URL to a "Pull Requests checklist if it is already present in the checklist"' do
+    checklist = Trello::Checklist.find(trello_poster_1.pr_checklist)
+
+    trello_poster_1.access_trello_card
+    trello_poster_1.post_github_pr_url
+
+    expect(checklist.check_items.count).to eq(1)
 
     checklist.delete_checklist_item(checklist.check_items.first['id'])
   end


### PR DESCRIPTION
- Now checks if a given PR URL is already present in the Pull Requests checklist before posting it