### PR TITLE
Install ruby-trello from Git repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: ruby
 rvm:
  - 2.3.0
-script: bundle exec rspec spec
+script:
+  - gem specific_install -l https://github.com/jeremytregunna/ruby-trello.git
+  - bundle exec rspec spec

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,9 @@ ruby '2.3.0'
 
 gem 'octokit', '~> 4.0'
 gem 'sinatra', require: 'sinatra/base'
-gem 'ruby-trello', :git => "https://github.com/jeremytregunna/ruby-trello.git", :branch => "master"
+# gem 'ruby-trello', :git => "https://github.com/jeremytregunna/ruby-trello.git", :branch => "master"
 gem 'dotenv'
+gem 'specific_install'
 
 group :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,54 +1,21 @@
-GIT
-  remote: https://github.com/jeremytregunna/ruby-trello.git
-  revision: 73e6e32af0a223d99a908463b58f3688cc5ad53d
-  branch: master
-  specs:
-    ruby-trello (1.5.0)
-      activemodel (>= 3.2.0)
-      addressable (~> 2.3)
-      json
-      oauth (>= 0.4.5)
-      rest-client (~> 1.8.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.0.0)
-      activesupport (= 5.0.0)
-    activesupport (5.0.0)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (~> 0.7)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
     addressable (2.4.0)
+    backports (3.6.8)
     byebug (9.0.5)
-    concurrent-ruby (1.0.2)
     diff-lcs (1.2.5)
-    domain_name (0.5.20160615)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.1)
     extlib (0.9.16)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     highline (1.7.8)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
-    i18n (0.7.0)
-    json (2.0.2)
-    mime-types (2.99.2)
-    minitest (5.9.0)
     multipart-post (2.0.0)
-    netrc (0.11.0)
-    oauth (0.5.1)
     octokit (4.3.0)
       sawyer (~> 0.7.0, >= 0.5.3)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -71,17 +38,13 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    specific_install (0.3.2)
+      backports
     templater (1.0.0)
       diff-lcs (>= 1.1.2)
       extlib (>= 0.9.5)
       highline (>= 1.4.0)
-    thread_safe (0.3.5)
     tilt (2.0.4)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
@@ -92,8 +55,8 @@ DEPENDENCIES
   octokit (~> 4.0)
   rspec
   rspec-sinatra
-  ruby-trello!
   sinatra
+  specific_install
 
 RUBY VERSION
    ruby 2.3.0p0

--- a/app.rb
+++ b/app.rb
@@ -3,7 +3,7 @@ require 'dotenv'
 Dotenv.load
 require './lib/github_pull_request'
 require 'json'
-
+ 
 class GDSGithubTrello < Sinatra::Base
 
   post '/payload' do


### PR DESCRIPTION
The ruby-trello gem is now installed directly from its Git repo using specific_install.  The previous implementation (referencing the repo in the Gemfile) worked for tests but not when app.rb is running - it wouldn't recognise the update_item_state method, which is required to check off an item on a checklist.